### PR TITLE
Fix crash

### DIFF
--- a/gzip.jl
+++ b/gzip.jl
@@ -288,9 +288,11 @@ function read_length_code(bs::BitStream, length_code)
     len = 0
     if (length_code < 265)
         return length_code - 254
-    else
+    elseif (length_code < 285)
         extra_bits = read_bits_inv(bs, div(length_code - 261,  4))
         return  extra_bits + extra_length_addend[length_code - 265 + 1]
+    else
+        return 258
     end
 end
 


### PR DESCRIPTION
I'm not enough of an expert on the gzip format to understand why this caused a crash, this code seems to have fixed it. I followed http://commandlinefanatic.com/cgi-bin/showarticle.cgi?article=art001

```
    // This is a back-pointer to a position in the stream
    // Interpret the length here as specified in 3.2.5
    if ( node->code < 265 )
    {
      length = node->code - 254;
    }
    else
    {
      if ( node->code < 285 )
      {
        extra_bits = read_bits_inv( stream, ( node->code - 261 ) / 4 );
        length = extra_bits + extra_length_addend[ node->code - 265 ];
      }
      else
      {
        length = 258;
      }
    }
```
