### PR TITLE
Fix depwarns with current Julia

### DIFF
--- a/gzip.jl
+++ b/gzip.jl
@@ -336,11 +336,11 @@ function inflate_block!(decoded_text, bs::BitStream)
     codes = read_second_tree_codes(bs, head, first_tree)
     
     literal_codes = codes[1:257 + head.hlit]
-    lit_code_table = create_code_table(literal_codes, [0:length(literal_codes)-1])
+    lit_code_table = create_code_table(literal_codes, collect(0:length(literal_codes)-1))
     literal_tree = create_huffman_tree(lit_code_table)
     
     distance_codes = codes[end-head.hdist:end]
-    dist_code_table = create_code_table(distance_codes, [0:length(distance_codes)-1])
+    dist_code_table = create_code_table(distance_codes, collect(0:length(distance_codes)-1))
     distance_tree = create_huffman_tree(dist_code_table)
     
     return inflate_block!(decoded_text, bs, literal_tree, distance_tree)

--- a/gzip.jl
+++ b/gzip.jl
@@ -157,7 +157,7 @@ function create_code_table(hclens, labels)
 end
 
 function make_bit_vector(n::Any, len::Any)
-    vec = BitVector(int(len))
+    vec = BitVector(Int(len))
     for i=1:len
         vec[len - i + 1] = n & 1
         n >>= 1

--- a/gzip.jl
+++ b/gzip.jl
@@ -42,11 +42,11 @@ Base.read(bs::BitStream, ::Type{HuffmanHeader}) = HuffmanHeader(
 
 
 
-has_ext(flags::GzipFlags)     = bool(0x01 & flags)
-has_crc(flags::GzipFlags)     = bool(0x02 & flags)
-has_extra(flags::GzipFlags)   = bool(0x04 & flags)
-has_name(flags::GzipFlags)    = bool(0x08 & flags)
-has_comment(flags::GzipFlags) = bool(0x10 & flags)
+has_ext(flags::GzipFlags)     = (0x01 & flags) != 0
+has_crc(flags::GzipFlags)     = (0x02 & flags) != 0
+has_extra(flags::GzipFlags)   = (0x04 & flags) != 0
+has_name(flags::GzipFlags)    = (0x08 & flags) != 0
+has_comment(flags::GzipFlags) = (0x10 & flags) != 0
 
 function Base.read(bs::BitStream, ::Type{BlockFormat})
     bits = read_bits(bs, 3)
@@ -187,7 +187,7 @@ function Base.setindex!(node::InternalNode, value::Node, dir::Bool)
         node.one = value
     end
 end
-Base.getindex(node::InternalNode, dir::Integer) = bool(dir) ? node.one : node.zero
+Base.getindex(node::InternalNode, dir::Integer) = dir != 0 ? node.one : node.zero
 function Base.getindex(node::InternalNode, code)
     for (i, bit) = enumerate(code)
         node = node[bit]


### PR DESCRIPTION
I attempted to run this (awesome) visualization with the latest version
of Julia (0.4.7), and got numerous deprecation warnings, obscuring the
lovely output.  This fixes all of those; `julia gzip.jl file.gz` now
runs without any depwarns.

(I also ended up filing https://github.com/JuliaLang/julia/issues/19686
because julia made it hard to find the source of the deprecation
warnings.)

Thanks for the amazing visualization; I went looking for an inflate
library I could hack to do this exact thing, and found your complete
implementation of exactly what I wanted instead.